### PR TITLE
quickfix - don't fail if no poses

### DIFF
--- a/robotapijs/scripts/robotapi.js
+++ b/robotapijs/scripts/robotapi.js
@@ -199,9 +199,11 @@ function Robot(robotId, apiDiv) {
     if (apiData.states != undefined)
       Robot.faces = apiData.states.faces;
       Robot.poses = [];
-      Object.entries(apiData.states.poses).forEach((elem, index) => {
-        Robot.poses.push({'name': elem[1].name});
-      })
+      if (apiData.states.poses) {
+        Object.entries(apiData.states.poses).forEach((elem, index) => {
+          Robot.poses.push({'name': elem[1].name});
+        })
+      }
     if (apiData.inputs != undefined)
       Robot.bellyScreens = apiData.inputs.bellyScreens;
     if (apiData.actions != undefined)


### PR DESCRIPTION
Programs for Navigation Menu Robot_copy were failing with `Uncaught TypeError: Cannot convert undefined or null to object` - after this change, program runs without this error