### PR TITLE
Make playSound sequential

### DIFF
--- a/robotapijs/scripts/robotapi.js
+++ b/robotapijs/scripts/robotapi.js
@@ -530,7 +530,19 @@ function Robot(robotId, apiDiv) {
   this.playSound = function(soundIndex){
     console.log("Playing sound: " + soundIndex);
     Robot._requestRobotAction("sound", {index:soundIndex});
-    //TODO: Implement callback for when action is done
+    var dbRef = firebase.database().ref(
+      "/robots/" + Robot.robotId + "/actions/sound/index"
+    );
+    return new Promise(function(resolve, reject) {
+      var dbRef = firebase.database().ref(
+        "/robots/" + Robot.robotId + "/actions/sound/index"
+      );
+      dbRef.on("value", async function(snapshot) {
+        if (snapshot.val() == -1) {
+          resolve("Sound task finished - Next!");
+        }
+      })
+    })
   }
 
   this.moveNeck = function(rotate, tilt, pan, turn) {

--- a/robotapijs/scripts/robotapi.js
+++ b/robotapijs/scripts/robotapi.js
@@ -77,7 +77,7 @@ function Robot(robotId, apiDiv) {
                        "<b>soundIndex</b> is an Integer between 0 and " +
                         (Robot.sounds.length-1) +  ", available sounds are:" +
                         Robot._getSoundNames(),
-                       "robot.playSound(0);");
+                       "await robot.playSound(0);");
     if (Robot.faces != null && Robot.faces.length>0)
       apiText += Robot._getAPICardHTML("robot.setFace(faceIndex)",
                         "Sets the robot's face to one of pre-designed faces.",

--- a/robotbackend/scripts/sound.js
+++ b/robotbackend/scripts/sound.js
@@ -25,8 +25,21 @@ function Sound() {
   }
 
   Sound.makeSound = function(soundIndex) {
+    return new Promise(function(resolve, reject) {
       var soundElementName = "sound" + soundIndex;
-      document.getElementById(soundElementName).play();
+      var this_sound = document.getElementById(soundElementName);
+      var play_promise = this_sound.play();
+      if (play_promise) {
+        play_promise.then(function() {}).catch(
+          function(error) {
+            reject(error);
+          }
+        )
+      }
+      this_sound.onended = function() {
+        resolve("finished playing sound " + soundIndex);
+      }
+    })
   }
 
   Sound.loadVoice = function(isCreateSelector) {


### PR DESCRIPTION
Added async compatibility with sounds, and have sounds wait until the "callback" of resetting the robot's sound index to -1 before playing the next sound.

This fixes the error of some sounds getting skipped in EUP and also makes sure sounds don't overlap with each other.

Before (current version in prod): https://drive.google.com/file/d/1G9AQQykThLrUwOjrecW82FC00d6pF9Bv/view?usp=sharing
With changes: https://drive.google.com/file/d/1Wc1AjrxTthAiKMg0Ed10lITk0fMAWKi8/view?usp=sharing