### PR TITLE
Persistent show/collapse

### DIFF
--- a/robotapijs/scripts/robotapi.js
+++ b/robotapijs/scripts/robotapi.js
@@ -18,6 +18,18 @@ function Robot(robotId, apiDiv) {
   
   Robot.setRobotId = function(robotId) {
     Robot.robotId = robotId;
+    
+    // reset current states
+    Robot.faces = null;
+    Robot.bellyScreens = null;
+    Robot.currentScreen = -1;
+    Robot.sounds = null;
+    Robot.tactile = null;
+    Robot.motors = null;
+    Robot.currentMotorState = null;
+    Robot.poses = null;
+    Robot.poseState = null;
+
     Robot.initialize();
   }
 
@@ -43,7 +55,7 @@ function Robot(robotId, apiDiv) {
       Robot.poseState = snapshot.val();
     })
 
-    console.log("Robot initialized.");
+    console.log("Robot initialized: " + Robot.robotId);
   }
 
   Robot.getAPIHTML = function() {

--- a/robotprogramming/run.html
+++ b/robotprogramming/run.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>EMAR Robot Programming</title>
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+  <link href="https://cdn.jsdelivr.net/gh/gitbrent/bootstrap4-toggle@3.6.1/css/bootstrap4-toggle.min.css" rel="stylesheet">
   <link rel="stylesheet" href="styles/index.processed.css">
   <link rel="stylesheet" href="../fontawesome/css/all.css">
 </head>
@@ -17,6 +18,10 @@
       <div class="col text-center">
         <h1 class="display-4">Robot Programs</h1>
       </div>
+      <div id="logClicks">
+        Track Clicks:
+        <input id="logClicksToggle" type="checkbox" data-toggle="toggle" data-size="sm">
+      </div>
     </div>
     <div class="row">
       <div class="col" id="robotList"><span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span></div>
@@ -25,6 +30,7 @@
   <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/gh/gitbrent/bootstrap4-toggle@3.6.1/js/bootstrap4-toggle.min.js"></script>
   <script src="https://mayacakmak.github.io/emarsoftware/robotbackend/scripts/config.js"></script>
   <script src="https://mayacakmak.github.io/emarsoftware/databasejs/scripts/database.js"></script>
   <script src="https://mayacakmak.github.io/emarsoftware/robotapijs/scripts/robotapi.js"></script>

--- a/robotprogramming/scripts/programming.js
+++ b/robotprogramming/scripts/programming.js
@@ -103,15 +103,13 @@ function updateMyProgramList(snapshot) {
   programsButtonDiv.innerHTML = "My programs";
 }
 
-function updateRobotList(snapshot) { 
-  console.log("UPDATE: ");
+function updateRobotList(snapshot) {
   let robotListHTML = "";
   let programRobotListHTML = "";
   let robots = snapshot.val();
-  delete robots["undefined"];
   robotNames = [];
   robotPrograms = [];
-  for (var i=0; i<Object.keys(robots).length; i++) {
+  for (var i=0; i<robots.length; i++) {
     robotNames.push(robots[i].name);
     robotPrograms.push(robots[i].programs);
 		robotListHTML += "<a class='dropdown-item' href='#' onclick='selectedRobotChanged(" +

--- a/robotprogramming/scripts/programming.js
+++ b/robotprogramming/scripts/programming.js
@@ -104,12 +104,14 @@ function updateMyProgramList(snapshot) {
 }
 
 function updateRobotList(snapshot) { 
+  console.log("UPDATE: ");
   let robotListHTML = "";
   let programRobotListHTML = "";
   let robots = snapshot.val();
+  delete robots["undefined"];
   robotNames = [];
   robotPrograms = [];
-  for (var i=0; i<robots.length; i++) {
+  for (var i=0; i<Object.keys(robots).length; i++) {
     robotNames.push(robots[i].name);
     robotPrograms.push(robots[i].programs);
 		robotListHTML += "<a class='dropdown-item' href='#' onclick='selectedRobotChanged(" +

--- a/robotprogramming/scripts/run.js
+++ b/robotprogramming/scripts/run.js
@@ -109,7 +109,3 @@ async function runProgram(robotId, programId) {
   eval("(async () => {" + codeText + "})();");
 }
 
-$('.btn-primary').on('click', function(e) {
-  e.stopPropagation();
-});
-

--- a/robotprogramming/scripts/run.js
+++ b/robotprogramming/scripts/run.js
@@ -44,11 +44,13 @@ function updateRobotList(snapshot) {
       expandButton.setAttribute('data-target', '#collapseRobot'+i);
       expandButton.setAttribute('aria-expanded', 'true');
       expandButton.setAttribute('aria-controls', 'collapseRobot'+i);
+      expandButton.setAttribute('onclick', 'prepRobotProgram('+ i + ')');
       expandButton.innerHTML = 'Programs on ' + robots[i].name;
 
       let collapseDiv = document.createElement('div');
       collapseDiv.setAttribute('class', 'collapse collapsed');
       collapseDiv.setAttribute('id', 'collapseRobot'+i);
+      collapseDiv.setAttribute('data-parent', '#robotList');
       collapseDiv.setAttribute('aria-labelledby', 'robot'+i);
             
       let cardBodyDiv = document.createElement('div');
@@ -102,7 +104,17 @@ function updateRobotList(snapshot) {
 
 }
 
+function prepRobotProgram(robotId) {
+  if (robotId != Robot.robotId) {
+    Robot.setRobotId(robotId);
+  }
+}
+
 async function runProgram(robotId, programId) {
+  // await prepRunProgram(robotId);
+  // if (robotId != Robot.robotId) {
+  //   Robot.setRobotId(robotId);
+  // }
   console.log("Will run program: " + robotPrograms[robotId][programId].name);
   let codeText = robotPrograms[robotId][programId].program;
   codeText = codeText.replace(/robot.sleep/g, "await robot.sleep");

--- a/robotprogramming/scripts/run.js
+++ b/robotprogramming/scripts/run.js
@@ -10,7 +10,7 @@ function initialize() {
   Robot.initialize(apiDiv);
 
   let dbRefRobot = firebase.database().ref('/robots/');
-  dbRefRobot.on("value", updateRobotList);
+  dbRefRobot.once("value", updateRobotList);
 }
 
 function updateRobotList(snapshot) { 
@@ -108,4 +108,8 @@ async function runProgram(robotId, programId) {
   codeText = codeText.replace(/robot.sleep/g, "await robot.sleep");
   eval("(async () => {" + codeText + "})();");
 }
+
+$('.btn-primary').on('click', function(e) {
+  e.stopPropagation();
+});
 

--- a/robotprogramming/scripts/run.js
+++ b/robotprogramming/scripts/run.js
@@ -111,10 +111,6 @@ function prepRobotProgram(robotId) {
 }
 
 async function runProgram(robotId, programId) {
-  // await prepRunProgram(robotId);
-  // if (robotId != Robot.robotId) {
-  //   Robot.setRobotId(robotId);
-  // }
   console.log("Will run program: " + robotPrograms[robotId][programId].name);
   let codeText = robotPrograms[robotId][programId].program;
   codeText = codeText.replace(/robot.sleep/g, "await robot.sleep");

--- a/robotprogramming/scripts/run.js
+++ b/robotprogramming/scripts/run.js
@@ -111,7 +111,16 @@ function prepRobotProgram(robotId) {
 }
 
 async function runProgram(robotId, programId) {
-  console.log("Will run program: " + robotPrograms[robotId][programId].name);
+  let robotListDiv = document.getElementById("logClicksToggle");
+  let programName = robotPrograms[robotId][programId].name
+
+  if (robotListDiv.checked) {
+    // Log timestamp to db if "Track Clicks" is toggled
+    robot.logData(programId, "run_program", "robot" + robotId, programName);
+    console.log("Logging in Firebase: " + programName);
+  }
+  
+  console.log("Will run program: " + programName);
   let codeText = robotPrograms[robotId][programId].program;
   codeText = codeText.replace(/robot.sleep/g, "await robot.sleep");
   eval("(async () => {" + codeText + "})();");


### PR DESCRIPTION
Previously the program run screen repopulated all its dropdowns and buttons whenever the firebase updated, including if the robot moved a motor. Removing that to only populate once initially to prevent menus from collapsing and needlessly re-pinging the db to update its programs

Video capture: https://drive.google.com/file/d/1K5eEM6HrSmc41PjzpqGfoZMZDC7D0AIB/view?usp=sharing