### PR TITLE
Finish button closes modal

### DIFF
--- a/robotprogramming/scripts/run.js
+++ b/robotprogramming/scripts/run.js
@@ -173,7 +173,7 @@ function operatorView(robotId, robotName) {
   `;
   for (let i = 0; i < finishPrograms.length; i++) {
     modalInnerHTML += finishPrograms[i].innerHTML
-      .replace("btn-primary", "btn-danger")
+      .replace("btn-primary", 'btn-danger" data-dismiss="modal')
       .replace("Run", "Finish");
   }
   modalInnerHTML += `


### PR DESCRIPTION
In operator view, allow the finish button to close the modal (while still running the finish program), signaling completion to the operator.

Video: https://drive.google.com/file/d/1afnPCAAcvc5rUSmp12LLN1hkDfWMguDd/view?usp=sharing